### PR TITLE
Add optional dispatcher state reload

### DIFF
--- a/modules/dispatcher/README
+++ b/modules/dispatcher/README
@@ -44,6 +44,7 @@ dispatcher Module
               1.3.29. socket_col (string)
               1.3.30. fetch_freeswitch_stats (integer)
               1.3.31. max_freeswitch_weight (integer)
+              1.3.32. reload_state (int)
 
         1.4. Exported Functions
 
@@ -134,6 +135,7 @@ dispatcher Module
    1.35. ds_count usage
    1.36. ds_is_in_list usage
    1.37. OpenSIPS config script - sample dispatcher usage
+   1.38. Set the reload_state parameter
 
 Chapter 1. Admin Guide
 
@@ -700,6 +702,19 @@ modparam("dispatcher", "fetch_freeswitch_stats", 1)
    Example 1.33. Set the max_freeswitch_weight parameter
 ...
 modparam("dispatcher", "max_freeswitch_weight", 1000)
+...
+
+1.3.32. reload_state (int)
+
+   Specifies whether the state column should be reloaded on ds_reload
+   MI command execution.
+
+   Default value is “0” (disable).
+
+   Example 1.38. Set the reload_state parameter
+...
+# enable reload state from DB when ds_reload is executed
+modparam("dispatcher", "reload_state", 1)
 ...
 
 1.4. Exported Functions

--- a/modules/dispatcher/dispatch.c
+++ b/modules/dispatcher/dispatch.c
@@ -1001,9 +1001,12 @@ int ds_reload_db(ds_partition_t *partition)
 
 	/* destroy old data */
 	if (old_data) {
-		/* copy the state of the destinations from the old set
-		 * (for the matching ids) */
-		ds_inherit_state( old_data, new_data);
+		/* only copy the old states if configured */
+		if (!ds_reload_state) {
+			/* copy the state of the destinations from the old set
+			 * (for the matching ids) */
+			ds_inherit_state( old_data, new_data);
+		}
 		ds_destroy_data_set( old_data );
 	}
 

--- a/modules/dispatcher/dispatch.h
+++ b/modules/dispatcher/dispatch.h
@@ -74,6 +74,7 @@
 
 
 extern int ds_persistent_state;
+extern int ds_reload_state;
 
 typedef struct _ds_dest
 {

--- a/modules/dispatcher/dispatcher.c
+++ b/modules/dispatcher/dispatcher.c
@@ -87,6 +87,7 @@ static int ds_ping_interval = 0;
 int ds_ping_maxfwd = -1;
 int ds_probing_mode = 0;
 int ds_persistent_state = 1;
+int ds_reload_state = 0;
 int_list_t *ds_probing_list = NULL;
 
 /* db partiton info */
@@ -276,6 +277,7 @@ static param_export_t params[]={
 	{"ds_probing_list",       STR_PARAM|USE_FUNC_PARAM, (void*)set_probing_list},
 	{"ds_define_blacklist",   STR_PARAM|USE_FUNC_PARAM, (void*)set_ds_bl},
 	{"persistent_state",      INT_PARAM, &ds_persistent_state},
+	{"reload_state",          INT_PARAM, &ds_reload_state},
 	{"fetch_freeswitch_stats", INT_PARAM, &fetch_freeswitch_stats},
 	{"max_freeswitch_weight", INT_PARAM, &max_freeswitch_weight},
 	{0,0,0}


### PR DESCRIPTION
We manage dispatcher files from an external application (SaltStack), including states, but these don't change in loaded dispatcher sets when running the ds_reload command, only after restarting the daemon.
We noticed this behavior is by design; because of that, we added a new flag to avoid the overwrite of the new states gathered from the DB with the old values loaded in memory. If the flag is not set, the behavior stays the same.
